### PR TITLE
Fix multi-line comment bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,10 @@ function tokenize(effects, ok, nok) {
       return nok(code)
     }
 
+    if (markdownLineEnding(code)) {
+      return atLineEnding(code);
+    }
+
     effects.enter(types.data)
 
     if (code === codes.dash) {

--- a/index.js
+++ b/index.js
@@ -178,7 +178,9 @@ function tokenize(effects, ok, nok) {
   function end(code) {
     if (code === codes.greaterThan) {
       effects.exit(types.data)
+      effects.enter('commentEnd') // See https://github.com/leebyron/remark-comment/pull/3#discussion_r1239494357
       effects.consume(code)
+      effects.exit('commentEnd')
       effects.exit('comment')
       return ok(code)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remark-comment",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-comment",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,6 @@
     "unified": "^10.1.1"
   },
   "scripts": {
-    "test": "node test.mjs"
+    "test": "node --conditions development test.mjs"
   }
 }

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -47,6 +47,10 @@ has a multi-line comment
 multi-line 
 comment -->
 
+<!--\\n\\n-->
+
+<!--\\na\\n\\nb\\n-->
+
 and a paragraph
 `
   ),
@@ -68,6 +72,10 @@ has a multi-line comment
 multi-line 
 comment -->
 
+<!--\\n\\n-->
+
+<!--\\na\\n\\nb\\n-->
+
 and a paragraph
 `,
     { ast: true }
@@ -83,6 +91,10 @@ has a multi-line comment
 <!-- another 
 multi-line 
 comment -->
+
+<!--\\n\\n-->
+
+<!--\\na\\n\\nb\\n-->
 
 and a paragraph
 `)
@@ -101,6 +113,10 @@ has a multi-line comment
 <!-- another 
 multi-line 
 comment -->
+
+<!--\\n\\n-->
+
+<!--\\na\\n\\nb\\n-->
 
 and a paragraph
 `
@@ -124,11 +140,15 @@ has a multi-line comment
 multi-line 
 comment -->
 
+<!--\\n\\n-->
+
+<!--\\na\\n\\nb\\n-->
+
 and a paragraph
 `,
     { ast: true }
   ),
-  '<h1>This document</h1>\n\n\n\n<p>and a paragraph</p>'
+  '<h1>This document</h1>\n\n\n\n\n\n<p>and a paragraph</p>'
 )
 
 // It renders to HTML via Micromark

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -39,6 +39,10 @@ assert.equal(
 
 <!-- has a comment -->
 
+<!--
+has a multi-line comment 
+-->
+
 and a paragraph
 `
   ),

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -43,6 +43,10 @@ assert.equal(
 has a multi-line comment 
 -->
 
+<!-- another 
+multi-line 
+comment -->
+
 and a paragraph
 `
   ),
@@ -56,12 +60,32 @@ assert.equal(
 
 <!-- has a comment -->
 
+<!--
+has a multi-line comment 
+-->
+
+<!-- another 
+multi-line 
+comment -->
+
 and a paragraph
 `,
     { ast: true }
   ),
-  '# This <!-- inline -->document\n\n<!-- has a comment -->\n\nand a paragraph\n'
-)
+    `# This <!-- inline -->document
+
+<!-- has a comment -->
+
+<!--
+has a multi-line comment 
+-->
+
+<!-- another 
+multi-line 
+comment -->
+
+and a paragraph
+`)
 
 // It renders to HTML via Rehype
 assert.equal(
@@ -69,6 +93,14 @@ assert.equal(
     `# This <!-- inline -->document
 
 <!-- has a comment -->
+
+<!--
+has a multi-line comment 
+-->
+
+<!-- another 
+multi-line 
+comment -->
 
 and a paragraph
 `
@@ -84,11 +116,19 @@ assert.equal(
 
 <!-- has a comment -->
 
+<!--
+has a multi-line comment 
+-->
+
+<!-- another 
+multi-line 
+comment -->
+
 and a paragraph
 `,
     { ast: true }
   ),
-  '<h1>This document</h1>\n\n<p>and a paragraph</p>'
+  '<h1>This document</h1>\n\n\n\n<p>and a paragraph</p>'
 )
 
 // It renders to HTML via Micromark
@@ -97,6 +137,14 @@ assert.equal(
     `# This <!-- inline -->document
 
 <!-- has a comment -->
+
+<!--
+has a multi-line comment 
+-->
+
+<!-- another 
+multi-line 
+comment -->
 
 and a paragraph
 `


### PR DESCRIPTION
Fix https://github.com/facebook/docusaurus/issues/9084

The tokenizer had a problem handling comment openings immediately followed by a line break.

Note, I did not update one of the tests (`It renders within HTML elements`) because I believe it does not seem to support multi-line comments in the first place (starting with line breaks or not): that is probably a separate bug to fix.



---

**Previous text before edit:**

WIP: for now it's just a unit test proof that this library has the bug reported here: https://github.com/facebook/docusaurus/issues/9084

No CI, so proof of local failure with a simple test case change:

<img width="1068" alt="CleanShot 2023-06-22 at 15 06 33@2x" src="https://github.com/leebyron/remark-comment/assets/749374/a7ae2920-bfed-45ca-85d5-e4394429e48a">
